### PR TITLE
Add support for static linking with a "static" crate feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zfp-sys"
-version = "0.1.9"
+version = "0.1.10"
 authors = ["jvo203 <chris.zapart@nao.ac.jp>"]
 edition = "2018"
 description = "Raw Rust bindings to ZFP (https://github.com/LLNL/zfp)."
@@ -17,3 +17,4 @@ cmake = "0.1"
 default = []
 cuda = []
 0_5_4 = []
+static = []

--- a/README.md
+++ b/README.md
@@ -2,15 +2,27 @@
 Raw Rust bindings to ZFP (https://github.com/LLNL/zfp).
 
 ## Crate features
+
+This crate allows a number of tweaks to compilation via crate features.
+
+### ZFP version
+
 The build supports compiling either zfp-0.5.4 or zfp-0.5.5. By default the newer v0.5.5 is used.
 There are design and speed differences between these two versions.
 In particular the default cache size has changed (see https://github.com/LLNL/zfp/issues/88).
 
 To use the previous version 0.5.4 one needs to set a feature flag "0_5_4", i.e. place this in your Cargo.toml:
 
-zfp-sys = {version = "*", features = ["0_5_4"]}
+    zfp-sys = {version = "*", features = ["0_5_4"]}
+
+### CUDA support
+
+Enable the `cuda` feature to enable GPU offloading by linking with CUDA libraries.
+See https://zfp.readthedocs.io/en/release0.5.5/execution.html for more information 
+on how this can be used in practice.
 
 ### Static linking
-Add the "static" feature to the crate dependency to link the zfp library statically.
-This also removes OpenMP support from the library, to remove the dependency on the dynamically linked
-openmp library.
+
+Add the `static` feature to the crate dependency to link the zfp library statically.
+This also removes OpenMP support from the library, to remove the dependency on
+the dynamically linked OpenMP library.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # zfp-sys
 Raw Rust bindings to ZFP (https://github.com/LLNL/zfp).
 
+## Crate features
 The build supports compiling either zfp-0.5.4 or zfp-0.5.5. By default the newer v0.5.5 is used.
 There are design and speed differences between these two versions.
 In particular the default cache size has changed (see https://github.com/LLNL/zfp/issues/88).
@@ -8,3 +9,8 @@ In particular the default cache size has changed (see https://github.com/LLNL/zf
 To use the previous version 0.5.4 one needs to set a feature flag "0_5_4", i.e. place this in your Cargo.toml:
 
 zfp-sys = {version = "*", features = ["0_5_4"]}
+
+### Static linking
+Add the "static" feature to the crate dependency to link the zfp library statically.
+This also removes OpenMP support from the library, to remove the dependency on the dynamically linked
+openmp library.


### PR DESCRIPTION
This new crate feature instructs CMake to build a static ZFP library, and adjusts the build script to link the static library. Currently this breaks OpenMP linking at least on my machine, which is regrettable, but on the flip side I wouldn't put it past the users of this crate to control threading on their own anyway. It's probably possible to fix OpenMP later. Thoughts?