### PR TITLE
Add the round-tight-error feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,3 +17,4 @@ cmake = "0.1"
 default = []
 cuda = []
 static = []
+round-tight-error = []

--- a/build.rs
+++ b/build.rs
@@ -27,6 +27,13 @@ fn main() {
         config.define("ZFP_WITH_OPENMP", "OFF");
     }
 
+    // Enable tighter errors with proper rounding and reduced bias
+    #[cfg(feature = "round-tight-error")]
+    {
+        config.define("ZFP_ROUNDING_MODE", "ZFP_ROUND_FIRST");
+        config.define("ZFP_WITH_TIGHT_ERROR", "ON");
+    }
+
     let zfp = config.build();
 
     println!("cargo:rustc-link-search=native={}/lib", zfp.display());


### PR DESCRIPTION
ZFP in its default configuration has a small bias. ZFP supports experimental rounding flags since v1.0.0. I propose adding a feature flag to enable them in an opinionated way:

- [`ZFP_ROUNDING_MODE=ZFP_ROUND_FIRST`](https://zfp.readthedocs.io/en/release1.0.0/installation.html#c.ZFP_ROUNDING_MODE) provides better rounding than `ZFP_ROUND_LAST` (both allow decompression with default builds but produce improved results)
- [`ZFP_WITH_TIGHT_ERROR=ON`](https://zfp.readthedocs.io/en/release1.0.0/installation.html#c.ZFP_WITH_TIGHT_ERROR) tightens the absolute error bound and improves the compression ratio but breaks compatibility with default builds

Together, they result in tighter errors, less bias, and improved compression ratios. If we'd want to retain compatibility, we could either split out the tight errors into a separate feature that requires rounding, and/or switch to `ZFP_ROUND_LAST` which improves the rounding during decompression, so also works for already-compressed data